### PR TITLE
Fixed the permissions setting script

### DIFF
--- a/helpers/fix-permissions.sh
+++ b/helpers/fix-permissions.sh
@@ -6,4 +6,4 @@ CURRENT_USER_ID=$(id -u)
 DOCKER_COMPOSE_CMD=$(find_docker_compose_command)
 
 $DOCKER_COMPOSE_CMD exec cakephp chown www-data:www-data /var/www/html
-$DOCKER_COMPOSE_CMD exec cakephp chown -R $CURRENT_USER_ID:www-data /var/www/html/*
+$DOCKER_COMPOSE_CMD exec cakephp chown -R $CURRENT_USER_ID:www-data /var/www/html/.*


### PR DESCRIPTION
Added the dot to avoid some permission changing issues like these:

chown: cannot access '/var/www/html/index.html': No such file or directory
chown: cannot access '/var/www/html/robots.txt': No such file or directory
chown: cannot access '/var/www/html/testem.js': No such file or directory